### PR TITLE
Implementation for DNS enabled host record

### DIFF
--- a/src/main/groovy/com/morpheusdata/infoblox/InfobloxProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/infoblox/InfobloxProvider.groovy
@@ -775,36 +775,47 @@ class InfobloxProvider implements IPAMProvider, DNSProvider {
 			}
 			def body
 			def networkView = networkPool.externalId.tokenize('/')[3]
+			def configureForDNS = (poolServer?.configMap?.configureForDNS == 'on') ? true : false
+			
+			def hostRecordName = null
+			if (configureForDNS) {
+				hostRecordName = hostname
+				createARecord = false
+			}
+			else {
+				hostRecordName = shortHostname
+			}
+
 			if (networkPool.type.code == 'infoblox') {
 				if(poolServer.serviceMode == 'dhcp' && networkPoolIp.macAddress) {
 					body = [
-						name: shortHostname,
+						name: hostRecordName,
 						network_view: networkView,
 						ipv4addrs: [[configure_for_dhcp: true, mac: networkPoolIp.macAddress, ipv4addr: networkPoolIp.ipAddress ?: "func:nextavailableip:${networkPool.externalId}".toString()]],
-						configure_for_dns: false
+						configure_for_dns: configureForDNS
 					]
 				} else {
 					body = [
-						name: shortHostname,
+						name: hostRecordName,
 						network_view: networkView,
 						ipv4addrs: [[configure_for_dhcp: false, ipv4addr: networkPoolIp.ipAddress ?: "func:nextavailableip:${networkPool.externalId}".toString()]],
-						configure_for_dns: false
+						configure_for_dns: configureForDNS
 					]
 				}
 			} else {
 				if(poolServer.serviceMode == 'dhcp' && networkPoolIp.macAddress) {
 					body = [
-						name: shortHostname,
+						name: hostRecordName,
 						network_view: networkView,
 						ipv6addrs: [[configure_for_dhcp: true, mac: networkPoolIp.macAddress, ipv6addr: networkPoolIp.ipAddress ?: "func:nextavailableip:${networkPool.externalId}".toString()]],
-						configure_for_dns: false
+						configure_for_dns: configureForDNS
 					]
 				} else {
 					body = [
-						name: shortHostname,
+						name: hostRecordName,
 						network_view: networkView,
 						ipv6addrs: [[configure_for_dhcp: false, ipv6addr: networkPoolIp.ipAddress ?: "func:nextavailableip:${networkPool.externalId}".toString()]],
-						configure_for_dns: false
+						configure_for_dns: configureForDNS
 					]
 				}
 			}
@@ -1397,11 +1408,12 @@ class InfobloxProvider implements IPAMProvider, DNSProvider {
 				new OptionType(code: 'infoblox.throttleRate', name: 'Throttle Rate', inputType: OptionType.InputType.NUMBER, defaultValue: 0, fieldName: 'serviceThrottleRate', fieldLabel: 'Throttle Rate', fieldContext: 'domain', displayOrder: 4),
 				new OptionType(code: 'infoblox.ignoreSsl', name: 'Ignore SSL', inputType: OptionType.InputType.CHECKBOX, defaultValue: 0, fieldName: 'ignoreSsl', fieldLabel: 'Disable SSL SNI Verification', fieldContext: 'domain', displayOrder: 5),
 				new OptionType(code: 'infoblox.inventoryExisting', name: 'Inventory Existing', inputType: OptionType.InputType.CHECKBOX, defaultValue: 0, fieldName: 'inventoryExisting', fieldLabel: 'Inventory Existing', fieldContext: 'config', displayOrder: 6),
-				new OptionType(code: 'infoblox.networkFilter', name: 'Network Filter', inputType: OptionType.InputType.TEXT, fieldName: 'networkFilter', fieldLabel: 'Network Filter', fieldContext: 'domain', displayOrder: 7),
-				new OptionType(code: 'infoblox.zoneFilter', name: 'Zone Filter', inputType: OptionType.InputType.TEXT, fieldName: 'zoneFilter', fieldLabel: 'Zone Filter', fieldContext: 'domain', displayOrder: 8),
-				new OptionType(code: 'infoblox.tenantMatch', name: 'Tenant Match Attribute', inputType: OptionType.InputType.TEXT, fieldName: 'tenantMatch', fieldLabel: 'Tenant Match Attribute', fieldContext: 'domain', displayOrder: 9),
-				new OptionType(code: 'infoblox.ipMode', name: 'IP Mode', inputType: OptionType.InputType.SELECT, fieldName: 'serviceMode', fieldLabel: 'IP Mode', fieldContext: 'domain', optionSource: 'infobloxModeTypeList' , displayOrder: 10),
-				new OptionType(code: 'infoblox.extraAttributes', name: 'Extra Attributes', inputType: OptionType.InputType.TEXTAREA, fieldName: 'extraAttributes', fieldLabel: 'Extra Attributes', fieldContext: 'config', displayOrder: 11, helpText: "Accepts a JSON input of custom attributes that can be saved on Host Record in Infoblox. These Must be first defined as extra attributes in Infoblox and values can be injected for the user creating the record and the date of assignment. The available injectable attributes are: userId, username, and dateCreated. They can be injected with <%=%>.")
+				new OptionType(code: 'infoblox.configureForDNS', name: 'Configure for DNS', inputType: OptionType.InputType.CHECKBOX, defaultValue: 0, fieldName: 'configureForDNS', fieldLabel: 'Use Host Record for DNS', fieldContext: 'config', displayOrder: 7),
+				new OptionType(code: 'infoblox.networkFilter', name: 'Network Filter', inputType: OptionType.InputType.TEXT, fieldName: 'networkFilter', fieldLabel: 'Network Filter', fieldContext: 'domain', displayOrder: 8),
+				new OptionType(code: 'infoblox.zoneFilter', name: 'Zone Filter', inputType: OptionType.InputType.TEXT, fieldName: 'zoneFilter', fieldLabel: 'Zone Filter', fieldContext: 'domain', displayOrder: 9),
+				new OptionType(code: 'infoblox.tenantMatch', name: 'Tenant Match Attribute', inputType: OptionType.InputType.TEXT, fieldName: 'tenantMatch', fieldLabel: 'Tenant Match Attribute', fieldContext: 'domain', displayOrder: 10),
+				new OptionType(code: 'infoblox.ipMode', name: 'IP Mode', inputType: OptionType.InputType.SELECT, fieldName: 'serviceMode', fieldLabel: 'IP Mode', fieldContext: 'domain', optionSource: 'infobloxModeTypeList' , displayOrder: 11),
+				new OptionType(code: 'infoblox.extraAttributes', name: 'Extra Attributes', inputType: OptionType.InputType.TEXTAREA, fieldName: 'extraAttributes', fieldLabel: 'Extra Attributes', fieldContext: 'config', displayOrder: 12, helpText: "Accepts a JSON input of custom attributes that can be saved on Host Record in Infoblox. These Must be first defined as extra attributes in Infoblox and values can be injected for the user creating the record and the date of assignment. The available injectable attributes are: userId, username, and dateCreated. They can be injected with <%=%>.")
 		]
 	}
 


### PR DESCRIPTION
Added new "Use host record for DNS" checkbox to Infoblox plugin settings to toggle behavior.


Added a conditional to handle differences between creating standard DNS records like before and DNS-enabled host records:

- Fully qualified name is necessary for Infoblox to assign parent zone for host record, if new checkbox is checked use qualified name for host record creation.
- If checked do not enter loop to create A and PTR records as this functionality is now handled by the DNS-enabled host record.
 